### PR TITLE
Implement exchange rates API with historical data, calculations and t…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-apache
+FROM php:8.2-apache
 
 WORKDIR /var/www/html
 

--- a/assets/js/components/HistoryRates.js
+++ b/assets/js/components/HistoryRates.js
@@ -1,0 +1,69 @@
+import React, {useEffect, useState} from 'react';
+import {useParams, useHistory} from 'react-router-dom';
+
+export default function HistoryRates() {
+    const {currency} = useParams();
+    const history = useHistory();
+    const [rates, setRates] = useState([]);
+    const [date, setDate] = useState(new Date().toISOString().substring(0, 10));
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        fetch(`/api/rates/history/${currency}/${date}`)
+            .then(res => {
+                if (!res.ok) {
+                    throw new Error(`HTTP ${res.status} - ${res.statusText}`);
+                }
+                return res.json();
+            })
+            .then(data => {
+                setRates(data);
+            })
+            .catch(err => {
+                setRates([]);
+                console.error(err);
+            });
+    }, [currency, date]);
+
+    return (
+        <div>
+            <h2>Historia kursu: {currency}</h2>
+            <button onClick={() => history.push('/rates')}>← Powrót</button>
+
+            <div style={{marginTop: '1rem'}}>
+                <label>Wybierz datę: </label>
+                <input
+                    type="date"
+                    value={date}
+                    onChange={e => setDate(e.target.value)}
+                    max={new Date().toISOString().substring(0, 10)}
+                />
+            </div>
+
+            {error && <div style={{color: 'red', marginTop: '1rem'}}>{error}</div>}
+
+            {!error && (
+                <table border="1" cellPadding="10" style={{marginTop: '1rem'}}>
+                    <thead>
+                    <tr>
+                        <th>Data</th>
+                        <th>Kurs średni</th>
+                        <th>Kupno</th>
+                        <th>Sprzedaż</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {rates.map(rate => (
+                        <tr key={rate.date}>
+                            <td>{rate.date}</td>
+                            <td>{rate.mid}</td>
+                            <td>{rate.buy || '-'}</td>
+                            <td>{rate.sell}</td>
+                        </tr>
+                    ))}
+                    </tbody>
+                </table>
+            )}
+        </div>
+    );
+}

--- a/assets/js/components/Home.js
+++ b/assets/js/components/Home.js
@@ -3,6 +3,8 @@
 import React, {Component} from 'react';
 import {Route, Redirect, Switch, Link} from 'react-router-dom';
 import SetupCheck from "./SetupCheck";
+import TodayRates from "./TodayRates";
+import HistoryRates from "./HistoryRates";
 
 class Home extends Component {
 
@@ -23,7 +25,10 @@ class Home extends Component {
                 <Switch>
                     <Redirect exact from="/" to="/setup-check" />
                     <Route path="/setup-check" component={SetupCheck} />
+                    <Route path="/rates" exact component={TodayRates} />
+                    <Route path="/history/:currency" component={HistoryRates} />
                 </Switch>
+
             </div>
         )
     }

--- a/assets/js/components/SetupCheck.js
+++ b/assets/js/components/SetupCheck.js
@@ -1,16 +1,10 @@
-// ./assets/js/components/Users.js
-
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import axios from 'axios';
 
 class SetupCheck extends Component {
     constructor() {
         super();
-        this.state = { setupCheck: {}, loading: true};
-    }
-
-    getBaseUrl() {
-        return 'http://telemedi-zadanie.localhost';
+        this.state = { setupCheck: {}, loading: true };
     }
 
     componentDidMount() {
@@ -18,15 +12,15 @@ class SetupCheck extends Component {
     }
 
     checkApiSetup() {
-        //const baseUrl = this.getBaseUrl();
-        const baseUrl = 'http://telemedi-zadanie.localhost';
-        axios.get(baseUrl + `/api/setup-check?testParam=1`).then(response => {
-            let responseIsOK = response.data && response.data.testParam === 1
-            this.setState({ setupCheck: responseIsOK, loading: false})
-        }).catch(function (error) {
-            console.error(error);
-            this.setState({ setupCheck: false, loading: false});
-        });
+        axios.get(`/api/setup-check?testParam=1`)
+            .then(response => {
+                const responseIsOK = response.data && response.data.testParam === 1;
+                this.setState({ setupCheck: responseIsOK, loading: false });
+            })
+            .catch((error) => {
+                console.error(error);
+                this.setState({ setupCheck: false, loading: false });
+            });
     }
 
     render() {
@@ -38,7 +32,6 @@ class SetupCheck extends Component {
                         <div className="row mt-5">
                             <div className="col-md-8 offset-md-2">
                                 <h2 className="text-center"><span>This is a test</span> @ Telemedi</h2>
-
                                 {loading ? (
                                     <div className={'text-center'}>
                                         <span className="fa fa-spin fa-spinner fa-4x"></span>
@@ -57,7 +50,8 @@ class SetupCheck extends Component {
                     </div>
                 </section>
             </div>
-        )
+        );
     }
 }
+
 export default SetupCheck;

--- a/assets/js/components/TodayRates.js
+++ b/assets/js/components/TodayRates.js
@@ -1,0 +1,46 @@
+import React, {useEffect, useState} from 'react';
+import {useHistory} from 'react-router-dom';
+
+export default function TodayRates() {
+    const [rates, setRates] = useState([]);
+    const history = useHistory();
+
+    useEffect(() => {
+        fetch('/api/rates/today')
+            .then(res => res.json())
+            .then(setRates)
+            .catch(console.error);
+    }, []);
+
+    return (
+        <div>
+            <h2>Dzisiejsze kursy</h2>
+            <table border="1" cellPadding="10">
+                <thead>
+                <tr>
+                    <th>Waluta</th>
+                    <th>Kurs średni</th>
+                    <th>Kupno</th>
+                    <th>Sprzedaż</th>
+                    <th></th>
+                </tr>
+                </thead>
+                <tbody>
+                {rates.map(rate => (
+                    <tr key={rate.currency}>
+                        <td>{rate.currency}</td>
+                        <td>{rate.mid}</td>
+                        <td>{rate.buy || '-'}</td>
+                        <td>{rate.sell}</td>
+                        <td>
+                            <button onClick={() => history.push(`/history/${rate.currency}`)}>
+                                Historia
+                            </button>
+                        </td>
+                    </tr>
+                ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -5,15 +5,16 @@
 #
 
 setupcheck:
-    path: /api/setup-check
-    controller: App\Controller\DefaultController::setupCheck
+  path: /api/setup-check
+  controller: App\Controller\DefaultController::setupCheck
+
+exchange_rates:
+  resource: '../src/App/Controller/ExchangeRateController.php'
+  type: annotation
 
 index:
-    path: /{wildcard}
-    defaults: {
-        _controller: App\Controller\DefaultController::index
-    }
-    requirements:
-        wildcard: .*
-    # controller: App\Controller\DefaultController::index
-
+  path: /{wildcard}
+  defaults:
+    _controller: App\Controller\DefaultController::index
+  requirements:
+    wildcard: .*

--- a/src/App/Controller/ExchangeRateController.php
+++ b/src/App/Controller/ExchangeRateController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use App\Service\NbpApiService;
+use App\Service\ExchangeRateCalculator;
+use GuzzleHttp\Exception\ClientException;
+use Symfony\Component\HttpFoundation\Request;
+
+#[Route('/api/rates')]
+class ExchangeRateController
+{
+    private NbpApiService $nbp;
+    private ExchangeRateCalculator $calc;
+    private array $allowedCurrencies = ['EUR', 'USD', 'CZK', 'IDR', 'BRL'];
+
+    public function __construct(NbpApiService $nbp, ExchangeRateCalculator $calc)
+    {
+        $this->nbp = $nbp;
+        $this->calc = $calc;
+    }
+
+    #[Route('/today', name: 'rates_today', methods: ['GET'])]
+    public function today(): JsonResponse
+    {
+        $currencies = ['EUR', 'USD', 'CZK', 'IDR', 'BRL'];
+        $data = [];
+
+        foreach ($currencies as $currency) {
+            $mid = $this->nbp->getLatestMidRate($currency);
+            if ($mid !== null) {
+                $data[] = $this->calc->calculateRate($currency, $mid, (new \DateTime())->format('Y-m-d'));
+            }
+        }
+
+        return new JsonResponse($data);
+    }
+
+    #[Route('/today', name: 'rates_today_post', methods: ['POST'])]
+    public function todayPost(): JsonResponse
+    {
+        return new JsonResponse(['error' => 'Method POST not allowed'], 405);
+    }
+
+    #[Route('/history/{currency}/{date}', name: 'rates_history', methods: ['GET'])]
+    public function history(string $currency, string $date): JsonResponse
+    {
+        $currency = strtoupper($currency);
+        if (!in_array($currency, ['EUR', 'USD', 'CZK', 'IDR', 'BRL'])) {
+            return new JsonResponse(['error' => 'Unsupported currency'], 400);
+        }
+
+        try {
+            $requestedDate = new \DateTime($date);
+        } catch (\Exception $e) {
+            return new JsonResponse(['error' => 'Invalid date format'], 400);
+        }
+
+        $today = new \DateTime();
+        if ($requestedDate > $today) {
+            return new JsonResponse(['error' => 'Date cannot be in the future'], 400);
+        }
+
+        try {
+            $rates = $this->nbp->getHistoricalRates($currency, $date);
+        } catch (ClientException $e) {
+            if ($e->getResponse() && $e->getResponse()->getStatusCode() === 404) {
+                return new JsonResponse(['error' => 'No data for given date'], 404);
+            }
+            return new JsonResponse(['error' => 'External API error'], 500);
+        }
+
+        if (empty($rates)) {
+            return new JsonResponse(['error' => 'No data for given date'], 404);
+        }
+
+        $data = [];
+        foreach ($rates as $rate) {
+            $data[] = $this->calc->calculateRate($currency, $rate['mid'], $rate['date']);
+        }
+
+        return new JsonResponse($data);
+    }
+
+}

--- a/src/App/Service/ExchangeRateCalculator.php
+++ b/src/App/Service/ExchangeRateCalculator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Service;
+
+class ExchangeRateCalculator
+{
+    public function calculateRate(string $currency, float $mid, string $date): array
+    {
+        $buy = null;
+        $sell = null;
+
+        if (in_array($currency, ['EUR', 'USD'])) {
+            $buy = round($mid - 0.15, 2);
+            $sell = round($mid + 0.11, 2);
+        } else {
+            $sell = round($mid + 0.20, 2);
+        }
+
+        return [
+            'currency' => $currency,
+            'mid' => $mid,
+            'buy' => $buy,
+            'sell' => $sell,
+            'date' => $date,
+        ];
+    }
+}

--- a/src/App/Service/NbpApiService.php
+++ b/src/App/Service/NbpApiService.php
@@ -1,0 +1,59 @@
+<?php
+namespace App\Service;
+
+use GuzzleHttp\Client;
+
+class NbpApiService
+{
+    private $client;
+
+    public function __construct()
+    {
+        $this->client = new Client(['base_uri' => 'https://api.nbp.pl/api/']);
+    }
+
+    public function getLatestMidRate(string $currency): ?float
+    {
+        $res = $this->client->get("exchangerates/rates/A/{$currency}/?format=json");
+        $data = json_decode($res->getBody()->getContents(), true);
+        return $data['rates'][0]['mid'] ?? null;
+    }
+    public function getAllMidRates(): array
+    {
+        $res = $this->client->get("exchangerates/tables/A/?format=json");
+        $data = json_decode($res->getBody()->getContents(), true);
+
+        $wanted = ['EUR', 'USD', 'CZK', 'IDR', 'BRL'];
+        $rates = [];
+
+        foreach ($data[0]['rates'] as $rate) {
+            if (in_array($rate['code'], $wanted)) {
+                $rates[$rate['code']] = $rate['mid'];
+            }
+        }
+
+        return $rates;
+    }
+
+    public function getHistoricalRates(string $currency, string $endDate, int $days = 14): array
+    {
+        $startDate = (new \DateTime($endDate))->modify('-30 days')->format('Y-m-d');
+
+        $res = $this->client->get("exchangerates/rates/A/{$currency}/{$startDate}/{$endDate}/?format=json");
+        $data = json_decode($res->getBody()->getContents(), true);
+
+        $rates = array_reverse($data['rates'] ?? []);
+        $rates = array_slice($rates, 0, $days);
+
+        return array_reverse(array_map(function ($rate) use ($currency) {
+            return [
+                'date' => $rate['effectiveDate'],
+                'mid' => $rate['mid'],
+                'currency' => $currency,
+            ];
+        }, $rates));
+    }
+
+
+
+}

--- a/tests/Controller/ExchangeRateControllerTest.php
+++ b/tests/Controller/ExchangeRateControllerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ExchangeRateControllerTest extends WebTestCase
+{
+    public function testTodayEndpoint()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/api/rates/today');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('Content-Type', 'application/json');
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertNotEmpty($data);
+    }
+
+    public function testHistoryEndpointValidDate()
+    {
+        $client = static::createClient();
+        $validDate = (new \DateTime('-1 week'))->format('Y-m-d');
+        $client->request('GET', "/api/rates/history/EUR/$validDate");
+
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertNotEmpty($data);
+    }
+
+    public function testHistoryEndpointFutureDate()
+    {
+        $client = static::createClient();
+        $futureDate = (new \DateTime('+1 day'))->format('Y-m-d');
+        $client->request('GET', "/api/rates/history/EUR/$futureDate");
+
+        $this->assertResponseStatusCodeSame(400);
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertArrayHasKey('error', $data);
+    }
+
+    public function testHistoryEndpointUnknownCurrency()
+    {
+        $client = static::createClient();
+        $validDate = (new \DateTime('-1 week'))->format('Y-m-d');
+        $client->request('GET', "/api/rates/history/XYZ/$validDate");
+
+        $this->assertResponseStatusCodeSame(400);
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertArrayHasKey('error', $data);
+    }
+
+    public function testHistoryEndpointNoData()
+    {
+        $client = static::createClient();
+        $oldDate = '1900-01-01';
+        $client->request('GET', "/api/rates/history/EUR/$oldDate");
+
+        $this->assertTrue(
+            $client->getResponse()->getStatusCode() === 404 ||
+            $client->getResponse()->getStatusCode() === 200
+        );
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertIsArray($data);
+        if ($client->getResponse()->getStatusCode() === 200) {
+            $this->assertEmpty($data);
+        }
+    }
+
+    public function testHistoryEndpointInvalidDateFormat()
+    {
+        $client = static::createClient();
+        $client->request('GET', "/api/rates/history/EUR/invalid-date");
+
+        $this->assertResponseStatusCodeSame(400);
+
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertArrayHasKey('error', $data);
+    }
+
+    public function testTodayEndpointPostMethodNotAllowed()
+    {
+        $client = static::createClient();
+        $client->request('POST', '/api/rates/today');
+
+        $this->assertResponseStatusCodeSame(405); // Method Not Allowed
+    }
+
+
+}


### PR DESCRIPTION
…ests

- Added ExchangeRateController with endpoints:
  - GET /api/rates/today for latest mid/buy/sell rates
  - GET /api/rates/history/{currency}/{date} for 14-day history
- Integrated NBP API via NbpApiService
- Implemented buy/sell margin rules in ExchangeRateCalculator
- Added validation and error handling (invalid currency/date, future date, no data)
- Created frontend views in React for today’s rates and historical rates
- Added functional tests covering success and edge cases




### Czas wykonania

Około 8 godzin 

### Feedback do zadania

Zadanie było realistyczne. Możliwość integracji z prawdziwym API NBP była na plus. 
Jedyna rzecz, która była trochę niewygodna — to rozdzielenie treści zadania: część była w README, a część w osobnym pliku z chmury. Dobrze byłoby mieć wszystko w jednym miejscu, żeby nie trzeba było przełączać się między źródłami.

### Podejście
- Stworzyłem kontroler i serwis do pobierania danych z NBP API
- Wdrożyłem przeliczanie kursów z marginesami kupna/sprzedaży
- Zaimplementowałem walidację danych wejściowych
- W React stworzyłem widoki na kursy dzisiejsze i historyczne
- Dodałem testy funkcjonalne z uwzględnieniem edge case’ów
